### PR TITLE
Support (Almost) all "standard" dunder objects

### DIFF
--- a/publication.py
+++ b/publication.py
@@ -42,6 +42,7 @@ PRIVATE_NAME = "_private"
 
 _nothing = object()
 
+
 def publish():
     # type: () -> None
     """
@@ -58,7 +59,17 @@ def publish():
     public = ModuleType(name)
     private = sys.modules[name]
     sys.modules[name] = public
-    names = all + ["__doc__", "__all__", "__path__"]
+    names = all + [
+        "__all__",
+        "__cached__",
+        "__doc__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
+    ]
     for published in names:
         value = getattr(private, published, _nothing)
         if value is not _nothing:


### PR DESCRIPTION
I couldn't find an authoritative list of dunder names that all module objects will have, so I just inspected what names were available on a single file module, a package, and a PEP 420 namespace package. I only checked this on Python 3.7.0 so it's possible other Pythons will have a different set.

The one item I left off the list, was ``__builtins__``, this didn't seem like something that should be exposed as "public" API, but I could be wrong? 